### PR TITLE
Add support for open on hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Color picker widget for Angular",
   "bugs": "https://github.com/zefoy/ngx-color-picker/issues",
   "license": "MIT",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "./bundles/ngx-color-picker.umd.js",
   "module": "./dist/ngx-color-picker.es5.js",
   "typings": "./dist/ngx-color-picker.d.ts",

--- a/src/lib/color-picker.component.html
+++ b/src/lib/color-picker.component.html
@@ -1,5 +1,5 @@
 <div #dialogPopup class="color-picker" [style.visibility]="hidden || !show ? 'hidden' : 'visible'" [style.top.px]="top" [style.left.px]="left" [style.position]="position" [style.height.px]="cpHeight" [style.width.px]="cpWidth" (click)="$event.stopPropagation()">
-  <div *ngIf="cpDialogDisplay=='popup'" class="arrow arrow-{{cpPosition}}" [style.top.px]="arrowTop"></div>
+  <div *ngIf="cpDialogDisplay=='popup' && !cpHideArrow" class="arrow arrow-{{cpPosition}}" [style.top.px]="arrowTop"></div>
 
   <div *ngIf="(cpColorMode || 1) === 1" class="saturation-lightness" [slider] [rgX]="1" [rgY]="1" [style.background-color]="hueSliderColor" (newValue)="onColorChange($event)" (dragStart)="onDragStart('saturation-lightness')" (dragEnd)="onDragEnd('saturation-lightness')">
     <div class="cursor" [style.top.px]="slider?.v" [style.left.px]="slider?.s"></div>

--- a/src/lib/color-picker.component.html
+++ b/src/lib/color-picker.component.html
@@ -1,5 +1,5 @@
 <div #dialogPopup class="color-picker" [style.visibility]="hidden || !show ? 'hidden' : 'visible'" [style.top.px]="top" [style.left.px]="left" [style.position]="position" [style.height.px]="cpHeight" [style.width.px]="cpWidth" (click)="$event.stopPropagation()">
-  <div *ngIf="cpDialogDisplay=='popup' && !cpHideArrow" class="arrow arrow-{{cpPosition}}" [style.top.px]="arrowTop"></div>
+  <div *ngIf="cpDialogDisplay=='popup'" class="arrow arrow-{{cpPosition}}" [style.top.px]="arrowTop"></div>
 
   <div *ngIf="(cpColorMode || 1) === 1" class="saturation-lightness" [slider] [rgX]="1" [rgY]="1" [style.background-color]="hueSliderColor" (newValue)="onColorChange($event)" (dragStart)="onDragStart('saturation-lightness')" (dragEnd)="onDragEnd('saturation-lightness')">
     <div class="cursor" [style.top.px]="slider?.v" [style.left.px]="slider?.s"></div>

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -8,6 +8,7 @@ import { ColorFormats, Hsla, Hsva, Rgba } from './formats';
 import { AlphaChannel, OutputFormat, SliderDimension, SliderPosition } from './helpers';
 
 import { ColorPickerService } from './color-picker.service';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'color-picker',
@@ -106,7 +107,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   public cpAddColorButtonClass: string;
   public cpRemoveColorButtonClass: string;
 
-  public cpHideArrow: boolean;
+  public colorPickerHover: Subject<boolean> = new Subject();
 
   @ViewChild('dialogPopup') dialogElement: ElementRef;
 
@@ -123,6 +124,14 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     if (this.show && this.cpDialogDisplay === 'popup') {
       this.onAcceptColor(event);
     }
+  }
+
+  @HostListener('mouseenter') handleMouseEnter(): void {
+    this.colorPickerHover.next(true);
+  }
+
+  @HostListener('mouseleave') handleMouseLeave(): void {
+    this.colorPickerHover.next(false);
   }
 
   constructor(private elRef: ElementRef, private cdRef: ChangeDetectorRef, private service: ColorPickerService) {}
@@ -198,7 +207,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     cpOKButton: boolean, cpOKButtonClass: string, cpOKButtonText: string,
     cpCancelButton: boolean, cpCancelButtonClass: string, cpCancelButtonText: string,
     cpAddColorButton: boolean, cpAddColorButtonClass: string, cpAddColorButtonText: string,
-    cpRemoveColorButtonClass: string, cpHideArrow: boolean): void
+    cpRemoveColorButtonClass: string): void
   {
     this.setInitialColor(color);
 
@@ -247,8 +256,6 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.cpAddColorButtonClass = cpAddColorButtonClass;
     this.cpRemoveColorButtonClass = cpRemoveColorButtonClass;
 
-    this.cpHideArrow = cpHideArrow;
-
     if (!cpPositionRelativeToArrow) {
       this.dialogArrowOffset = 0;
     }
@@ -262,11 +269,6 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
         cpAlphaChannel !== 'always' && cpAlphaChannel !== 'forced')
     {
       this.cpAlphaChannel = 'disabled';
-    }
-
-    if (!cpHideArrow) {
-      this.dialogArrowOffset = 0;
-      this.dialogArrowSize = 0;
     }
   }
 

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -106,6 +106,8 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   public cpAddColorButtonClass: string;
   public cpRemoveColorButtonClass: string;
 
+  public cpHideArrow: boolean;
+
   @ViewChild('dialogPopup') dialogElement: ElementRef;
 
   @ViewChild('hueSlider') hueSlider: ElementRef;
@@ -196,7 +198,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     cpOKButton: boolean, cpOKButtonClass: string, cpOKButtonText: string,
     cpCancelButton: boolean, cpCancelButtonClass: string, cpCancelButtonText: string,
     cpAddColorButton: boolean, cpAddColorButtonClass: string, cpAddColorButtonText: string,
-    cpRemoveColorButtonClass: string): void
+    cpRemoveColorButtonClass: string, cpHideArrow: boolean): void
   {
     this.setInitialColor(color);
 
@@ -245,6 +247,8 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.cpAddColorButtonClass = cpAddColorButtonClass;
     this.cpRemoveColorButtonClass = cpRemoveColorButtonClass;
 
+    this.cpHideArrow = cpHideArrow;
+
     if (!cpPositionRelativeToArrow) {
       this.dialogArrowOffset = 0;
     }
@@ -258,6 +262,11 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
         cpAlphaChannel !== 'always' && cpAlphaChannel !== 'forced')
     {
       this.cpAlphaChannel = 'disabled';
+    }
+
+    if (!cpHideArrow) {
+      this.dialogArrowOffset = 0;
+      this.dialogArrowSize = 0;
     }
   }
 

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -9,6 +9,7 @@ import { AlphaChannel, OutputFormat, SliderDimension, SliderPosition } from './h
 
 import { ColorPickerService } from './color-picker.service';
 import { Subject } from 'rxjs';
+import { ColorPickerDirective } from './color-picker.directive';
 
 @Component({
   selector: 'color-picker',
@@ -31,7 +32,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   private listenerResize: any;
   private listenerMouseDown: any;
 
-  private directiveInstance: any;
+  private directiveInstance: ColorPickerDirective;
 
   private sliderH: number;
   private sliderDimMax: SliderDimension;
@@ -197,7 +198,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.closeColorPicker();
   }
 
-  public setupDialog(instance: any, elementRef: ElementRef, color: any,
+  public setupDialog(instance: ColorPickerDirective, elementRef: ElementRef, color: any,
     cpWidth: string, cpHeight: string, cpDialogDisplay: string, cpFallbackColor: string,
     cpColorMode: string, cpAlphaChannel: AlphaChannel, cpOutputFormat: OutputFormat,
     cpDisableInput: boolean, cpIgnoredElements: any, cpSaveClickOutside: boolean,

--- a/src/lib/color-picker.directive.ts
+++ b/src/lib/color-picker.directive.ts
@@ -69,6 +69,8 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
 
   @Input() cpRemoveColorButtonClass: string = 'cp-remove-color-button-class';
 
+  @Input() cpHideArrow: boolean = false;
+
   @Output() cpInputChange = new EventEmitter<any>(true);
 
   @Output() cpToggleChange = new EventEmitter<boolean>(true);
@@ -174,7 +176,7 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
         this.cpOKButton, this.cpOKButtonClass, this.cpOKButtonText,
         this.cpCancelButton, this.cpCancelButtonClass, this.cpCancelButtonText,
         this.cpAddColorButton, this.cpAddColorButtonClass, this.cpAddColorButtonText,
-        this.cpRemoveColorButtonClass);
+        this.cpRemoveColorButtonClass, this.cpHideArrow);
 
       this.dialog = this.cmpRef.instance;
 


### PR DESCRIPTION
Adds support for opening the color picker by hovering over the color picker input, using a new `cpOpenOnHover` input on the `colorPicker` directive.

Hover events of both the color picker dialog and the color picker input are subscribed to, so that the color picker will remain open as long as the user hovers above any of the two elements. A 250ms delay is added to dismiss the color picker dialog so that it is not dismissed while the user moves from the input to the dialog.